### PR TITLE
JVM flag -XX:HotswapDeoptClassPath=<class_path> support added

### DIFF
--- a/hotspot/.hg/patches/full-jdk7u45-deopt-cp.patch
+++ b/hotspot/.hg/patches/full-jdk7u45-deopt-cp.patch
@@ -1,0 +1,228 @@
+diff --git a/src/share/vm/classfile/classFileParser.cpp b/src/share/vm/classfile/classFileParser.cpp
+index a6d138b..8edc030 100644
+--- a/src/share/vm/classfile/classFileParser.cpp
++++ b/src/share/vm/classfile/classFileParser.cpp
+@@ -3942,6 +3942,14 @@
+       }
+     }
+ 
++    if (cfs->source() != NULL && HotswapDeoptClassPath != NULL)
++    {
++    	if (strstr(cfs->source(), HotswapDeoptClassPath) != NULL)
++    	{
++    		this_klass->set_deoptimization_incl(true);
++    	}
++    }
++
+     if (TraceClassResolution) {
+       // print out the superclass.
+       const char * from = Klass::cast(this_klass())->external_name();
+diff --git a/src/share/vm/classfile/systemDictionary.cpp b/src/share/vm/classfile/systemDictionary.cpp
+index fa45c6d..a0a695b 100644
+--- a/src/share/vm/classfile/systemDictionary.cpp
++++ b/src/share/vm/classfile/systemDictionary.cpp
+@@ -1255,6 +1255,14 @@
+       }
+     }
+ 
++    if (HotswapDeoptClassPath != NULL)
++    {
++    	if (strstr(HotswapDeoptClassPath, ik->external_name()) != NULL)
++    	{
++    		ik->set_deoptimization_incl(true);
++    	}
++    }
++
+     if (TraceClassLoading) {
+       ResourceMark rm;
+       tty->print("[Loaded %s", ik->external_name());
+diff --git a/src/share/vm/code/codeCache.cpp b/src/share/vm/code/codeCache.cpp
+index 70574bc..b28cb02 100644
+--- a/src/share/vm/code/codeCache.cpp
++++ b/src/share/vm/code/codeCache.cpp
+@@ -715,6 +715,14 @@
+ 
+ 
+ // Deoptimize all methods
++void CodeCache::mark_all_incl_nmethods_for_deoptimization() {
++  MutexLockerEx mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
++  FOR_ALL_ALIVE_NMETHODS(nm) {
++    nm->mark_for_deoptimization_incl();
++  }
++}
++
++// Deoptimize all methods
+ void CodeCache::mark_all_nmethods_for_deoptimization() {
+   MutexLockerEx mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+   FOR_ALL_ALIVE_NMETHODS(nm) {
+diff --git a/src/share/vm/code/codeCache.hpp b/src/share/vm/code/codeCache.hpp
+index a670805..0206b48 100644
+--- a/src/share/vm/code/codeCache.hpp
++++ b/src/share/vm/code/codeCache.hpp
+@@ -186,6 +186,7 @@
+ #endif // HOTSWAP
+ 
+   static void mark_all_nmethods_for_deoptimization();
++  static void mark_all_incl_nmethods_for_deoptimization();
+   static int  mark_for_deoptimization(methodOop dependee);
+   static void make_marked_nmethods_zombies();
+   static void make_marked_nmethods_not_entrant();
+diff --git a/src/share/vm/code/nmethod.cpp b/src/share/vm/code/nmethod.cpp
+index 21c9413..0c3a9a0 100644
+--- a/src/share/vm/code/nmethod.cpp
++++ b/src/share/vm/code/nmethod.cpp
+@@ -465,6 +465,7 @@
+   _lazy_critical_native       = 0;
+   _has_wide_vectors           = 0;
+   _marked_for_deoptimization  = 0;
++  _deoptimization_incl        = false;
+   _lock_count                 = 0;
+   _stack_traversal_mark       = 0;
+   _unload_reported            = false;           // jvmti state
+diff --git a/src/share/vm/code/nmethod.hpp b/src/share/vm/code/nmethod.hpp
+index 8d76afb..d2d1acc 100644
+--- a/src/share/vm/code/nmethod.hpp
++++ b/src/share/vm/code/nmethod.hpp
+@@ -169,6 +169,8 @@
+   bool _marked_for_reclamation;              // Used by NMethodSweeper (set only by sweeper)
+   bool _marked_for_deoptimization;           // Used for stack deoptimization
+ 
++  bool _deoptimization_incl;
++
+   // used by jvmti to track if an unload event has been posted for this nmethod.
+   bool _unload_reported;
+ 
+@@ -412,6 +414,11 @@
+   bool  is_marked_for_deoptimization() const      { return _marked_for_deoptimization; }
+   void  mark_for_deoptimization()                 { _marked_for_deoptimization = true; }
+ 
++  bool  is_deoptimization_incl() const            { return _deoptimization_incl; }
++  void  set_deoptimization_incl(bool z)           { _deoptimization_incl = z; }
++
++  void  mark_for_deoptimization_incl()            { if (_deoptimization_incl) _marked_for_deoptimization = true; }
++
+   void  make_unloaded(BoolObjectClosure* is_alive, oop cause);
+ 
+   bool has_dependencies()                         { return dependencies_size() != 0; }
+diff --git a/src/share/vm/oops/klass.cpp b/src/share/vm/oops/klass.cpp
+index 767588c..e84bc6f 100644
+--- a/src/share/vm/oops/klass.cpp
++++ b/src/share/vm/oops/klass.cpp
+@@ -57,7 +57,10 @@
+ 
+ void Klass::update_supers_to_newest_version() {
+ 
+-  if (super() != NULL) set_super(super()->klass_part()->newest_version());
++  if (super() != NULL) {
++  	set_super(super()->klass_part()->newest_version());
++  	set_deoptimization_incl(super()->klass_part()->is_deoptimization_incl());
++  }
+   
+   for (uint i=0; i<primary_super_limit(); i++) {
+     klassOop cur = _primary_supers[i];
+@@ -183,6 +186,7 @@
+ 
+   kl->set_redefinition_flags(Klass::NoRedefinition);
+   kl->set_redefining(false);
++  kl->set_deoptimization_incl(false);
+   kl->set_new_version(NULL);
+   kl->set_old_version(NULL);
+   kl->set_redefinition_index(-1);
+@@ -256,6 +260,9 @@
+   if (FastSuperclassLimit == 0) {
+     // None of the other machinery matters.
+     set_super(k);
++    if (k != NULL) {
++    	set_deoptimization_incl(k->klass_part()->is_deoptimization_incl());
++    }
+     return;
+   }
+   if (k == NULL) {
+@@ -267,6 +274,7 @@
+            "initialize this only once to a non-trivial value");
+     set_super(k);
+     Klass* sup = k->klass_part();
++  	set_deoptimization_incl(sup->is_deoptimization_incl());
+     int sup_depth = sup->super_depth();
+     juint my_depth  = MIN2(sup_depth + 1, (int)primary_super_limit());
+     if (!can_be_primary_super_slow())
+diff --git a/src/share/vm/oops/klass.hpp b/src/share/vm/oops/klass.hpp
+index d086b5d..0719b90 100644
+--- a/src/share/vm/oops/klass.hpp
++++ b/src/share/vm/oops/klass.hpp
+@@ -303,6 +303,7 @@
+   char                  _field_redefinition_policy;
+   char                  _static_field_redefinition_policy;
+   bool                  _is_redefining;
++  bool                  _deoptimization_incl; // True if class methods are included in deoptimization
+ 
+ #ifndef PRODUCT
+   int           _verify_count;  // to avoid redundant verifies
+@@ -387,6 +388,9 @@
+     else { return _old_version->klass_part()->is_same_or_older_version(klass); }
+   }
+ 
++  bool  is_deoptimization_incl() const            { return _deoptimization_incl; }
++  void  set_deoptimization_incl(bool z)           { _deoptimization_incl = z; }
++
+   // Revision number for redefined classes, -1 for originally loaded classes
+   jint revision_number() const {
+     return _revision_number;
+diff --git a/src/share/vm/prims/jvmtiRedefineClasses.cpp b/src/share/vm/prims/jvmtiRedefineClasses.cpp
+index ef4f380..d134534 100644
+--- a/src/share/vm/prims/jvmtiRedefineClasses.cpp
++++ b/src/share/vm/prims/jvmtiRedefineClasses.cpp
+@@ -2580,7 +2580,8 @@
+     }*/
+ 
+     Klass *k = k_oop->klass_part();
+-    if (k->oop_is_instance()) {
++
++    if (k->oop_is_instance() && (HotswapDeoptClassPath == NULL || k->is_deoptimization_incl())) {
+       HandleMark hm(THREAD);
+       instanceKlass *ik = (instanceKlass *) k;
+ 
+@@ -2683,7 +2684,11 @@
+   if (0 && JvmtiExport::all_dependencies_are_recorded()) {
+     Universe::flush_evol_dependents_on(k_h);
+   } else {
+-    CodeCache::mark_all_nmethods_for_deoptimization();
++
++  	if (HotswapDeoptClassPath == NULL)
++  		CodeCache::mark_all_nmethods_for_deoptimization();
++  	else
++    	CodeCache::mark_all_incl_nmethods_for_deoptimization();
+ 
+     ResourceMark rm(THREAD);
+     DeoptimizationMarker dm;
+diff --git a/src/share/vm/runtime/globals.hpp b/src/share/vm/runtime/globals.hpp
+index 634c589..eeb0558 100644
+--- a/src/share/vm/runtime/globals.hpp
++++ b/src/share/vm/runtime/globals.hpp
+@@ -3659,7 +3659,13 @@
+   product(bool, EnableTracing, false,                                       \
+                   "Enable event-based tracing")                             \
+   product(bool, UseLockedTracing, false,                                    \
+-          "Use locked-tracing when doing event-based tracing")
++          "Use locked-tracing when doing event-based tracing")              \
++  product(ccstr, HotswapDeoptClassPath, NULL,                               \
++          "Class path or fragment of the class path to a folder with "      \
++          "classes allowed to be deoptimized on hotswap. If is not "        \
++          "defined then all classes will be deoptimized on hotswap. "       \
++          "That's default behaviour. Using this option the performance "    \
++          "of hotswap can considerably increased. ")
+ 
+ /*
+  *  Macros for factoring of globals
+diff --git a/src/share/vm/runtime/sharedRuntime.cpp b/src/share/vm/runtime/sharedRuntime.cpp
+index e0e19b1..ae28d1a 100644
+--- a/src/share/vm/runtime/sharedRuntime.cpp
++++ b/src/share/vm/runtime/sharedRuntime.cpp
+@@ -2630,6 +2630,7 @@
+                                                   sig_bt,
+                                                   regs,
+                                                   ret_type);
++     	nm->set_deoptimization_incl(method->method_holder()->klass_part()->is_deoptimization_incl());
+     }
+   }
+ 

--- a/hotspot/.hg/patches/series
+++ b/hotspot/.hg/patches/series
@@ -17,4 +17,4 @@ full-jdk7u51-b13.patch  #+full-jdk7u51-b13
 light-jdk7u40-b43.patch #+light-jdk7u40-b43
 light-jdk7u51-b13.patch #+light-jdk7u51-b13 #+light-jdk7u55-b13
 light-jdk8u5-b13.patch  #+light-jdk8u5-b13
-
+full-jdk7u45-deopt-cp.patch #+full-jdk7u45-b08


### PR DESCRIPTION
This patch adds a new  JVM flag -XX:HotswapDeoptClassPath=<path_fragment> used for class path definition for NONFIXED code. All classes on this path are deoptimized (fired from code cache) on hotswap. Classes from JARs, typically huge amount of frameworks classes stay in the cache. Without this patch or without HotswapDeoptClassPath flag definition all classes  are fired from code cache. HotswapDeoptClassPath considerably improves performance of DCEVM hotswap. 
  This is temporary solution untill class - dependency problem will be solved.
