### PR TITLE
Force set deoptimization_incl flag for all hotswapped classes

### DIFF
--- a/hotspot/.hg/patches/full-jdk7u45-deopt-cp.patch
+++ b/hotspot/.hg/patches/full-jdk7u45-deopt-cp.patch
@@ -169,10 +169,19 @@ index d086b5d..0719b90 100644
    jint revision_number() const {
      return _revision_number;
 diff --git a/src/share/vm/prims/jvmtiRedefineClasses.cpp b/src/share/vm/prims/jvmtiRedefineClasses.cpp
-index ef4f380..d134534 100644
+index ef4f380..5d2382c 100644
 --- a/src/share/vm/prims/jvmtiRedefineClasses.cpp
 +++ b/src/share/vm/prims/jvmtiRedefineClasses.cpp
-@@ -2580,7 +2580,8 @@
+@@ -435,6 +435,8 @@
+ 
+     new_class->set_redefinition_flags(redefinition_flags);
+ 
++    new_class->set_deoptimization_incl(true);
++
+     _max_redefinition_flags = _max_redefinition_flags | redefinition_flags;
+ 
+     if ((redefinition_flags & Klass::ModifyInstances) != 0) {
+@@ -2580,7 +2582,8 @@
      }*/
  
      Klass *k = k_oop->klass_part();
@@ -182,7 +191,7 @@ index ef4f380..d134534 100644
        HandleMark hm(THREAD);
        instanceKlass *ik = (instanceKlass *) k;
  
-@@ -2683,7 +2684,11 @@
+@@ -2683,7 +2686,11 @@
    if (0 && JvmtiExport::all_dependencies_are_recorded()) {
      Universe::flush_evol_dependents_on(k_h);
    } else {

--- a/hotspot/.hg/patches/full-jdk7u51-deopt-cp.patch
+++ b/hotspot/.hg/patches/full-jdk7u51-deopt-cp.patch
@@ -169,10 +169,19 @@ index d086b5d..0719b90 100644
    jint revision_number() const {
      return _revision_number;
 diff --git a/src/share/vm/prims/jvmtiRedefineClasses.cpp b/src/share/vm/prims/jvmtiRedefineClasses.cpp
-index ef4f380..d134534 100644
+index ef4f380..5d2382c 100644
 --- a/src/share/vm/prims/jvmtiRedefineClasses.cpp
 +++ b/src/share/vm/prims/jvmtiRedefineClasses.cpp
-@@ -2580,7 +2580,8 @@
+@@ -435,6 +435,8 @@
+ 
+     new_class->set_redefinition_flags(redefinition_flags);
+ 
++    new_class->set_deoptimization_incl(true);
++
+     _max_redefinition_flags = _max_redefinition_flags | redefinition_flags;
+ 
+     if ((redefinition_flags & Klass::ModifyInstances) != 0) {
+@@ -2580,7 +2582,8 @@
      }*/
  
      Klass *k = k_oop->klass_part();
@@ -182,7 +191,7 @@ index ef4f380..d134534 100644
        HandleMark hm(THREAD);
        instanceKlass *ik = (instanceKlass *) k;
  
-@@ -2683,7 +2684,11 @@
+@@ -2683,7 +2686,11 @@
    if (0 && JvmtiExport::all_dependencies_are_recorded()) {
      Universe::flush_evol_dependents_on(k_h);
    } else {


### PR DESCRIPTION
Deopt include flag was lost for all hotswapped classes since the hotswapped classes are loaded from stream SystemDictionary::resolve_from_stream (...)  in jvmtiRedefineClasses.cpp. This patch sets this flag to true for hotswapped class. It is absolutely correct, since it forced to fire the old classes code from the code cache. The patch doesn't affect other functionality.
