### PR TITLE
Fix problem with java8 breakpoints

### DIFF
--- a/hotspot/.hg/patches/jvmti-getLoadedClasses-java8.patch
+++ b/hotspot/.hg/patches/jvmti-getLoadedClasses-java8.patch
@@ -1,0 +1,19 @@
+diff --git a/src/share/vm/prims/jvmtiGetLoadedClasses.cpp b/src/share/vm/prims/jvmtiGetLoadedClasses.cpp
+index 70aede5..381868b 100644
+--- a/src/share/vm/prims/jvmtiGetLoadedClasses.cpp
++++ b/src/share/vm/prims/jvmtiGetLoadedClasses.cpp
+@@ -42,7 +42,13 @@
+ 
+   void do_klass(Klass* k) {
+     // Collect all jclasses
+-    _classStack.push((jclass) _env->jni_reference(k->java_mirror()));
++    // DCEVM : LoadedClassesClosure in dcevm7 iterates over classes from SystemDictionary therefore the class "k" is always
++    //         the new version (SystemDictionary stores only new versions). But the LoadedClassesClosure's functionality was
++    //         changed in java8  where jvmtiLoadedClasses collects all classes from all classloaders, therefore we
++    //         must use new versions only.
++    if (k->new_version()==NULL) {
++      _classStack.push((jclass) _env->jni_reference(k->java_mirror()));
++    }
+   }
+ 
+   int extract(jclass* result_list) {

--- a/hotspot/.hg/patches/series
+++ b/hotspot/.hg/patches/series
@@ -49,6 +49,7 @@ light-jdk8u20-b22.patch  #+light-jdk8u20-b22 #+light-jdk8u31-b13
 light-jdk8u40-b25.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16
 light-jdk8u66-b17.patch #+light-jdk8u66-b17 #+light-jdk8u74-b02
 light-jdk8u92-b14.patch #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16
+jvmti-getLoadedClasses-java8.patch #+light-jdk8u112-b16
 light-jdk8u20-deopt-cp.patch #+light-jdk8u20-b22 #+light-jdk8u31-b13 #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16
 light-jdk8u66-b17-deopt-cp.patch #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16
 dont-clear-f1.patch #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16


### PR DESCRIPTION
Jvmti GetLoadedClasses collects classes from classloaders
in java8 while java7 collects it from SystemDictionary. Dcevm7/8
holds only new classes in Dictionary while classloader holds
all versions including old one. Therefore dcevm8 must return
only new version in jvmti getLoadedClasses.