### PR TITLE
Refactored Functional Interface to Specialized Primitive Functional Interface

### DIFF
--- a/dcevm/src/test/java8/com/github/dcevm/test/lambdas/LambdaTest.java
+++ b/dcevm/src/test/java8/com/github/dcevm/test/lambdas/LambdaTest.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.concurrent.Callable;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 
 import static com.github.dcevm.test.util.HotSwapTestHelper.__toVersion__;
 import static com.github.dcevm.test.util.HotSwapTestHelper.__version__;
@@ -87,7 +87,7 @@ public class LambdaTest {
     }
   }
 
-  public static void methodWithLambdaParam(Consumer<Integer> consumer) {
+  public static void methodWithLambdaParam(IntConsumer consumer) {
     consumer.accept(1);
   }
 
@@ -108,7 +108,7 @@ public class LambdaTest {
   // version 0
   public static class LambdaC3 {
     public int i = 0;
-    public Consumer<Integer> l = x -> i += x;
+    public IntConsumer l = x -> i += x;
 
     public void doit() {
       LambdaTest.methodWithLambdaParam(l);
@@ -118,7 +118,7 @@ public class LambdaTest {
   // version 1
   public static class LambdaC3___1 {
     int i = 0;
-    public Consumer<Integer> l = null;
+    public IntConsumer l = null;
 
     public void doit() {
       LambdaTest.methodWithLambdaParam(l);


### PR DESCRIPTION
Hello,

I am a graduate student at Oregon State University and as a part of my research and subject CS562 Applied Software Engineering project (Study and Refactoring of Functional Interface in Java), I have done refactoring of the functional interface namely:

Consumer<Integer> --> IntConsumer 

 the file `LambaTest`, the functional interface Consumer<Integer> is consumed as the `int`. So, Java Compiler has to autobox the Integer to int. However Java 8 has provided primitive specialized functional interface. Now, Java compiler does not have to` autobox` Integer to int and so we get performance boost.
  
My project and research deals with the boxing and unboxing of Wrapper Class and the primitive data-types. I want to know that whether the open source community is ready to accept these micro-optimizing refactoring or not.

Thank you,
Harsh Thakor