### PR TITLE
Jdk8u172

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,5 +51,4 @@ targetJre=build/jre
 #hotspotTag=jdk8u112-b16
 #hotspotTag=jdk8u144-b01
 #hotspotTag=jdk8u152-b16
-#hotspotTag=jdk8u161-b12
-hotspotTag=jdk8u162-b12
+hotspotTag=jdk8u172-b11

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,4 +50,5 @@ targetJre=build/jre
 #hotspotTag=jdk8u111-b14
 #hotspotTag=jdk8u112-b16
 #hotspotTag=jdk8u144-b01
-hotspotTag=jdk8u152-b16
+#hotspotTag=jdk8u152-b16
+hotspotTag=jdk8u161-b12

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,4 +51,5 @@ targetJre=build/jre
 #hotspotTag=jdk8u112-b16
 #hotspotTag=jdk8u144-b01
 #hotspotTag=jdk8u152-b16
-hotspotTag=jdk8u161-b12
+#hotspotTag=jdk8u161-b12
+hotspotTag=jdk8u162-b12

--- a/hotspot/.hg/patches/dmh-field-accessors-java8u172.patch
+++ b/hotspot/.hg/patches/dmh-field-accessors-java8u172.patch
@@ -1,0 +1,166 @@
+Add support for DirectMethodHandle field implementations (StaticAccessor/Accessor).
+
+During the redefinition run, these instances are updated to point to new field index location.
+# HG changeset patch
+# Parent a5d69314e0a8e05605ca678e31eeba92ec173400
+
+diff -r a5d69314e0a8 src/share/vm/classfile/javaClasses.cpp
+--- a/src/share/vm/classfile/javaClasses.cpp	Tue Mar 31 18:05:19 2015 -0700
++++ b/src/share/vm/classfile/javaClasses.cpp	Tue Mar 31 18:06:35 2015 -0700
+@@ -2667,6 +2667,50 @@
+   }
+ }
+ 
++// Support for java_lang_invoke_DirectMethodHandle$StaticAccessor
++
++int java_lang_invoke_DirectMethodHandle_StaticAccessor::_static_offset_offset;
++
++long java_lang_invoke_DirectMethodHandle_StaticAccessor::static_offset(oop dmh) {
++  assert(_static_offset_offset != 0, "");
++  return dmh->long_field(_static_offset_offset);
++}
++
++void java_lang_invoke_DirectMethodHandle_StaticAccessor::set_static_offset(oop dmh, long static_offset) {
++  assert(_static_offset_offset != 0, "");
++  dmh->long_field_put(_static_offset_offset, static_offset);
++}
++
++
++void java_lang_invoke_DirectMethodHandle_StaticAccessor::compute_offsets() {
++  Klass* klass_oop = SystemDictionary::DirectMethodHandle_StaticAccessor_klass();
++  if (klass_oop != NULL && EnableInvokeDynamic) {
++    compute_offset(_static_offset_offset, klass_oop, vmSymbols::static_offset_name(), vmSymbols::long_signature());
++  }
++}
++
++// Support for java_lang_invoke_DirectMethodHandle$Accessor
++
++int java_lang_invoke_DirectMethodHandle_Accessor::_field_offset_offset;
++
++int java_lang_invoke_DirectMethodHandle_Accessor::field_offset(oop dmh) {
++  assert(_field_offset_offset != 0, "");
++  return dmh->int_field(_field_offset_offset);
++}
++
++void java_lang_invoke_DirectMethodHandle_Accessor::set_field_offset(oop dmh, int field_offset) {
++  assert(_field_offset_offset != 0, "");
++  dmh->int_field_put(_field_offset_offset, field_offset);
++}
++
++
++void java_lang_invoke_DirectMethodHandle_Accessor::compute_offsets() {
++  Klass* klass_oop = SystemDictionary::DirectMethodHandle_Accessor_klass();
++  if (klass_oop != NULL && EnableInvokeDynamic) {
++    compute_offset(_field_offset_offset, klass_oop, vmSymbols::field_offset_name(), vmSymbols::int_signature());
++  }
++}
++
+ // Support for java_lang_invoke_MethodHandle
+ 
+ int java_lang_invoke_MethodHandle::_type_offset;
+@@ -3343,6 +3387,9 @@
+     java_lang_invoke_LambdaForm::compute_offsets();
+     java_lang_invoke_MethodType::compute_offsets();
+     java_lang_invoke_CallSite::compute_offsets();
++
++    java_lang_invoke_DirectMethodHandle_StaticAccessor::compute_offsets();
++    java_lang_invoke_DirectMethodHandle_Accessor::compute_offsets();
+   }
+   java_security_AccessControlContext::compute_offsets();
+   // Initialize reflection classes. The layouts of these classes
+diff -r a5d69314e0a8 src/share/vm/classfile/javaClasses.hpp
+--- a/src/share/vm/classfile/javaClasses.hpp	Tue Mar 31 18:05:19 2015 -0700
++++ b/src/share/vm/classfile/javaClasses.hpp	Tue Mar 31 18:06:35 2015 -0700
+@@ -1020,6 +1020,55 @@
+   static int member_offset_in_bytes()           { return _member_offset; }
+ };
+ 
++// Interface to java.lang.invoke.DirectMethodHandle$StaticAccessor objects
++
++class java_lang_invoke_DirectMethodHandle_StaticAccessor: AllStatic {
++  friend class JavaClasses;
++
++ private:
++  static int _static_offset_offset;               // offset to static field
++
++  static void compute_offsets();
++
++ public:
++  // Accessors
++  static long      static_offset(oop dmh);
++  static void  set_static_offset(oop dmh, long value);
++
++  // Testers
++  static bool is_subclass(Klass* klass) {
++    return klass->is_subclass_of(SystemDictionary::DirectMethodHandle_StaticAccessor_klass());
++  }
++  static bool is_instance(oop obj) {
++    return obj != NULL && is_subclass(obj->klass());
++  }
++};
++
++// Interface to java.lang.invoke.DirectMethodHandle$Accessor objects
++
++class java_lang_invoke_DirectMethodHandle_Accessor: AllStatic {
++  friend class JavaClasses;
++
++ private:
++  static int _field_offset_offset;               // offset to field
++
++  static void compute_offsets();
++
++ public:
++  // Accessors
++  static int      field_offset(oop dmh);
++  static void set_field_offset(oop dmh, int value);
++
++  // Testers
++  static bool is_subclass(Klass* klass) {
++    return klass->is_subclass_of(SystemDictionary::DirectMethodHandle_Accessor_klass());
++  }
++  static bool is_instance(oop obj) {
++    return obj != NULL && is_subclass(obj->klass());
++  }
++};
++
++
+ // Interface to java.lang.invoke.LambdaForm objects
+ // (These are a private interface for managing adapter code generation.)
+ 
+diff -r a5d69314e0a8 src/share/vm/classfile/systemDictionary.hpp
+--- a/src/share/vm/classfile/systemDictionary.hpp	Tue Mar 31 18:05:19 2015 -0700
++++ b/src/share/vm/classfile/systemDictionary.hpp	Tue Mar 31 18:06:35 2015 -0700
+@@ -153,6 +153,8 @@
+                                                                                                                          \
+   /* support for dynamic typing; it's OK if these are NULL in earlier JDKs */                                            \
+   do_klass(DirectMethodHandle_klass,                    java_lang_invoke_DirectMethodHandle,       Opt                 ) \
++  do_klass(DirectMethodHandle_StaticAccessor_klass,     java_lang_invoke_DirectMethodHandle_StaticAccessor, Opt        ) \
++  do_klass(DirectMethodHandle_Accessor_klass,           java_lang_invoke_DirectMethodHandle_Accessor, Opt              ) \
+   do_klass(MethodHandle_klass,                          java_lang_invoke_MethodHandle,             Pre_JSR292          ) \
+   do_klass(MemberName_klass,                            java_lang_invoke_MemberName,               Pre_JSR292          ) \
+   do_klass(MethodHandleNatives_klass,                   java_lang_invoke_MethodHandleNatives,      Pre_JSR292          ) \
+diff -r a5d69314e0a8 src/share/vm/classfile/vmSymbols.hpp
+--- a/src/share/vm/classfile/vmSymbols.hpp	Tue Mar 31 18:05:19 2015 -0700
++++ b/src/share/vm/classfile/vmSymbols.hpp	Tue Mar 31 18:06:35 2015 -0700
+@@ -265,6 +265,8 @@
+   template(java_lang_invoke_CallSite,                 "java/lang/invoke/CallSite")                \
+   template(java_lang_invoke_ConstantCallSite,         "java/lang/invoke/ConstantCallSite")        \
+   template(java_lang_invoke_DirectMethodHandle,       "java/lang/invoke/DirectMethodHandle")      \
++  template(java_lang_invoke_DirectMethodHandle_StaticAccessor, "java/lang/invoke/DirectMethodHandle$StaticAccessor") \
++  template(java_lang_invoke_DirectMethodHandle_Accessor, "java/lang/invoke/DirectMethodHandle$Accessor") \
+   template(java_lang_invoke_MutableCallSite,          "java/lang/invoke/MutableCallSite")         \
+   template(java_lang_invoke_VolatileCallSite,         "java/lang/invoke/VolatileCallSite")        \
+   template(java_lang_invoke_MethodHandle,             "java/lang/invoke/MethodHandle")            \
+@@ -414,6 +416,10 @@
+   template(getProtectionDomain_name,                  "getProtectionDomain")                      \
+   template(getProtectionDomain_signature,             "(Ljava/security/CodeSource;)Ljava/security/ProtectionDomain;") \
+   template(url_code_signer_array_void_signature,      "(Ljava/net/URL;[Ljava/security/CodeSigner;)V") \
++  template(static_offset_name,                        "staticOffset")                             \
++  template(static_base_name,                          "staticBase")                               \
++  template(field_offset_name,                         "fieldOffset")                              \
++  template(field_type_name,                           "fieldType")                                \
+   template(referencequeue_null_name,                  "NULL")                                     \
+   template(referencequeue_enqueued_name,              "ENQUEUED")                                 \
+                                                                                                   \
+   /* non-intrinsic name/signature pairs: */                                                       \
+   template(register_method_name,                      "register")                                 \

--- a/hotspot/.hg/patches/series
+++ b/hotspot/.hg/patches/series
@@ -4,18 +4,18 @@ distro-name.patch
 # Add AllowEnhancedRedefinition argument
 arguments-java8.patch #+light-jdk8u5-b13 #+light-jdk8u20-b22
 arguments-java8u31.patch #+light-jdk8u31-b13
-arguments-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
+arguments-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
 
 # GC changes to allow modifying instances during redefinition run
 gc-java8.patch #+light-jdk8u5-b13 #+light-jdk8u20-b22 #+light-jdk8u31-b13
-gc-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
+gc-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
 
 # Add support for certain DMH implementations
 dmh-field-accessors-java8.patch #+light-jdk8u5-b13 #+light-jdk8u20-b22 #+light-jdk8u31-b13
-dmh-field-accessors-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
+dmh-field-accessors-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
 
 # Stub JVM_SetVmMemoryPressure function
-JVM_SetVmMemoryPressure.patch #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
+JVM_SetVmMemoryPressure.patch #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
 
 # Rest of the changes
 full-jdk7u11-b21.patch  #+full-jdk7u11-b21
@@ -50,9 +50,9 @@ light-jdk8u40-b25.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-
 light-jdk8u66-b17.patch #+light-jdk8u66-b17 #+light-jdk8u74-b02
 light-jdk8u92-b14.patch #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14
 light-jdk8u112-b16.patch #+light-jdk8u112-b16 #+light-jdk8u144-b01
-light-jdk8u152-b16.patch #+light-jdk8u152-b16 #+light-jdk8u161-b12
-jvmti-getLoadedClasses-java8.patch #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
+light-jdk8u152-b16.patch #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
+jvmti-getLoadedClasses-java8.patch #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
 jvmti-lockRedefine-java8.patch #+light-jdk8u144-b01delete
 light-jdk8u20-deopt-cp.patch #+light-jdk8u20-b22 #+light-jdk8u31-b13 #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16
-light-jdk8u66-b17-deopt-cp.patch #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
-dont-clear-f1.patch #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
+light-jdk8u66-b17-deopt-cp.patch #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
+dont-clear-f1.patch #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12

--- a/hotspot/.hg/patches/series
+++ b/hotspot/.hg/patches/series
@@ -4,18 +4,18 @@ distro-name.patch
 # Add AllowEnhancedRedefinition argument
 arguments-java8.patch #+light-jdk8u5-b13 #+light-jdk8u20-b22
 arguments-java8u31.patch #+light-jdk8u31-b13
-arguments-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16
+arguments-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
 
 # GC changes to allow modifying instances during redefinition run
 gc-java8.patch #+light-jdk8u5-b13 #+light-jdk8u20-b22 #+light-jdk8u31-b13
-gc-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16
+gc-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
 
 # Add support for certain DMH implementations
 dmh-field-accessors-java8.patch #+light-jdk8u5-b13 #+light-jdk8u20-b22 #+light-jdk8u31-b13
-dmh-field-accessors-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16
+dmh-field-accessors-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
 
 # Stub JVM_SetVmMemoryPressure function
-JVM_SetVmMemoryPressure.patch #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16
+JVM_SetVmMemoryPressure.patch #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
 
 # Rest of the changes
 full-jdk7u11-b21.patch  #+full-jdk7u11-b21
@@ -50,9 +50,9 @@ light-jdk8u40-b25.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-
 light-jdk8u66-b17.patch #+light-jdk8u66-b17 #+light-jdk8u74-b02
 light-jdk8u92-b14.patch #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14
 light-jdk8u112-b16.patch #+light-jdk8u112-b16 #+light-jdk8u144-b01
-light-jdk8u152-b16.patch #+light-jdk8u152-b16
-jvmti-getLoadedClasses-java8.patch #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16
+light-jdk8u152-b16.patch #+light-jdk8u152-b16 #+light-jdk8u161-b12
+jvmti-getLoadedClasses-java8.patch #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
 jvmti-lockRedefine-java8.patch #+light-jdk8u144-b01delete
 light-jdk8u20-deopt-cp.patch #+light-jdk8u20-b22 #+light-jdk8u31-b13 #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16
-light-jdk8u66-b17-deopt-cp.patch #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16
-dont-clear-f1.patch #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16
+light-jdk8u66-b17-deopt-cp.patch #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12
+dont-clear-f1.patch #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12

--- a/hotspot/.hg/patches/series
+++ b/hotspot/.hg/patches/series
@@ -4,18 +4,19 @@ distro-name.patch
 # Add AllowEnhancedRedefinition argument
 arguments-java8.patch #+light-jdk8u5-b13 #+light-jdk8u20-b22
 arguments-java8u31.patch #+light-jdk8u31-b13
-arguments-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
+arguments-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u172-b11
 
 # GC changes to allow modifying instances during redefinition run
 gc-java8.patch #+light-jdk8u5-b13 #+light-jdk8u20-b22 #+light-jdk8u31-b13
-gc-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
+gc-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u172-b11
 
 # Add support for certain DMH implementations
 dmh-field-accessors-java8.patch #+light-jdk8u5-b13 #+light-jdk8u20-b22 #+light-jdk8u31-b13
-dmh-field-accessors-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
+dmh-field-accessors-java8u40.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16
+dmh-field-accessors-java8u172.patch #+light-jdk8u172-b11
 
 # Stub JVM_SetVmMemoryPressure function
-JVM_SetVmMemoryPressure.patch #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
+JVM_SetVmMemoryPressure.patch #+light-jdk8u45-b14 #+light-jdk8u51-b16 #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u172-b11
 
 # Rest of the changes
 full-jdk7u11-b21.patch  #+full-jdk7u11-b21
@@ -50,10 +51,10 @@ light-jdk8u40-b25.patch #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-
 light-jdk8u66-b17.patch #+light-jdk8u66-b17 #+light-jdk8u74-b02
 light-jdk8u92-b14.patch #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14
 light-jdk8u112-b16.patch #+light-jdk8u112-b16 #+light-jdk8u144-b01
-light-jdk8u152-b16.patch #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
-jvmti-getLoadedClasses-java8.patch #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u161-b12 #+light-jdk8u162-b12
+light-jdk8u152-b16.patch #+light-jdk8u152-b16 #+light-jdk8u172-b11
+jvmti-getLoadedClasses-java8.patch #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u172-b11
 jvmti-lockRedefine-java8.patch #+light-jdk8u144-b01delete
 light-jdk8u20-deopt-cp.patch #+light-jdk8u20-b22 #+light-jdk8u31-b13 #+light-jdk8u40-b25 #+light-jdk8u45-b14 #+light-jdk8u51-b16
-light-jdk8u66-b17-deopt-cp.patch #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16
-dont-clear-f1.patch #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16
-light-updateClassRedefinedCount-java8.patch #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16
+light-jdk8u66-b17-deopt-cp.patch #+light-jdk8u66-b17 #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u172-b11
+dont-clear-f1.patch #+light-jdk8u74-b02 #+light-jdk8u92-b14 #+light-jdk8u102-b31 #+light-jdk8u111-b14 #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u172-b11
+light-updateClassRedefinedCount-java8.patch #+light-jdk8u112-b16 #+light-jdk8u144-b01 #+light-jdk8u152-b16 #+light-jdk8u172-b11


### PR DESCRIPTION
update to JDK8u172.
Sadly previous changes wasn't working. We had conflict during patching with dmh-field-accessors-java8u40.patch, it seems that in src/share/vm/classfile/vmSymbols.hpp getProtectionDomain have 2 new templates, and this was making problems with patching.
Tested with build on Linux x64 with JDK8u172