### PR TITLE
Changes to display JVM installations on macOS/OSX.

### DIFF
--- a/installer/src/main/java/com/github/dcevm/installer/ConfigurationInfo.java
+++ b/installer/src/main/java/com/github/dcevm/installer/ConfigurationInfo.java
@@ -37,13 +37,19 @@ import java.util.regex.Pattern;
  * @author Christoph Wimberger
  * @author Ivan Dubrov
  * @author Jiri Bubnik
+ * @author Przemysław Rumik
  */
 public enum ConfigurationInfo {
 
     // Note: 32-bit is not supported on Mac OS X
     MAC_OS(null, "bsd_amd64_compiler2",
             "lib/client", "lib/server", "lib/dcevm", "lib/server", "lib/dcevm",
-            "bin/java", "libjvm.dylib"),
+            "bin/java", "libjvm.dylib") {
+        @Override
+        public String[] paths() {
+            return new String[] { "/Library/Java/JavaVirtualMachines/" };
+        }
+    },
     LINUX("linux_i486_compiler2", "linux_amd64_compiler2",
             "lib/i386/client", "lib/i386/server", "lib/i386/dcevm", "lib/amd64/server", "lib/amd64/dcevm",
             "bin/java", "libjvm.so") {
@@ -78,11 +84,11 @@ public enum ConfigurationInfo {
     private final String javaExecutable;
     private final String libraryName;
 
-    private ConfigurationInfo(String resourcePath32, String resourcePath64,
-                              String clientPath,
-                              String server32Path, String dcevm32Path,
-                              String server64Path, String dcevm64Path,
-                              String javaExecutable, String libraryName) {
+    ConfigurationInfo(String resourcePath32, String resourcePath64,
+                      String clientPath,
+                      String server32Path, String dcevm32Path,
+                      String server64Path, String dcevm64Path,
+                      String javaExecutable, String libraryName) {
         this.resourcePath32 = resourcePath32;
         this.resourcePath64 = resourcePath64;
         this.clientPath = clientPath;
@@ -211,7 +217,7 @@ public enum ConfigurationInfo {
         return result.toString();
     }
 
-    public boolean isDCEInstalled(Path dir, boolean altjvm) throws IOException {
+    public boolean isDCEInstalled(Path dir, boolean altjvm) {
         Path jreDir;
         if (isJDK(dir)) {
             jreDir = dir.resolve("jre");
@@ -243,7 +249,7 @@ public enum ConfigurationInfo {
         }
     }
 
-    public String getVersionString(Path jreDir, boolean altjvm) throws IOException {
+    public String getVersionString(Path jreDir, boolean altjvm) {
         try {
             if (altjvm) {
                 return executeJava(jreDir,  "-XXaltjvm=dcevm", "-version");
@@ -255,7 +261,7 @@ public enum ConfigurationInfo {
         }
     }
 
-    public boolean is64Bit(Path jreDir) throws IOException {
+    public boolean is64Bit(Path jreDir) {
         return getVersionString(jreDir, false).contains("64-Bit");
     }
 
@@ -267,7 +273,7 @@ public enum ConfigurationInfo {
         return getVersionHelper(jreDir, ".*Dynamic Code Evolution.*build ([^,]+),.*", false, altjvm);
     }
 
-    private String getVersionHelper(Path jreDir, String regex, boolean javaVersion, boolean altjvm) throws IOException {
+    private String getVersionHelper(Path jreDir, String regex, boolean javaVersion, boolean altjvm) {
         String version = getVersionString(jreDir, altjvm);
         version = version.replaceAll("\n", "");
         Matcher matcher = Pattern.compile(regex).matcher(version);

--- a/installer/src/main/java/com/github/dcevm/installer/InstallUninstallAction.java
+++ b/installer/src/main/java/com/github/dcevm/installer/InstallUninstallAction.java
@@ -42,7 +42,7 @@ class InstallUninstallAction extends AbstractAction implements ListSelectionList
     /**
      * Buttons to add/remove DCEVM.
      */
-    public static enum Type {
+    public enum Type {
         UNINSTALL("Uninstall"),
         INSTALL("Replace by DCEVM"),
         INSTALL_ALTJVM("Install DCEVM as altjvm");

--- a/installer/src/main/java/com/github/dcevm/installer/Installer.java
+++ b/installer/src/main/java/com/github/dcevm/installer/Installer.java
@@ -34,6 +34,7 @@ import java.util.List;
  * @author Christoph Wimberger
  * @author Ivan Dubrov
  * @author Jiri Bubnik
+ * @author Przemysław Rumik
  */
 public class Installer {
 
@@ -166,15 +167,26 @@ public class Installer {
 
     private void scanDirectory(DirectoryStream<Path> stream, List<Installation> installations) {
         for (Path path : stream) {
-            if (Files.isDirectory(path) && (config.isJDK(path) || config.isJRE(path))) {
-                try {
-                    Installation inst = new Installation(config, path);
-                    if (!installations.contains(inst)) {
-                        installations.add(inst);
+            if (Files.isDirectory(path)) {
+                if (config.isJDK(path) || config.isJRE(path)) {
+                    try {
+                        Installation inst = new Installation(config, path);
+                        if (!installations.contains(inst)) {
+                            installations.add(inst);
+                        }
+                    } catch (Exception ex) {
+                        // FIXME: just ignore the installation for now..
+                        ex.printStackTrace();
                     }
-                } catch (Exception ex) {
-                    // FIXME: just ignore the installation for now..
-                    ex.printStackTrace();
+                } else {
+                    // in macOS/OSX we have more complicated strucuture of directories with JVM...
+                    // for example it may be /Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home
+                    // so we will look deper in structure of passed folders hoping that we will find JVM ;-)
+                    try {
+                        scanDirectory(Files.newDirectoryStream(path),installations);
+                    } catch (IOException ignore) {
+
+                    }
                 }
             }
         }

--- a/installer/src/main/java/com/github/dcevm/installer/MainWindow.java
+++ b/installer/src/main/java/com/github/dcevm/installer/MainWindow.java
@@ -33,6 +33,7 @@ import java.io.IOException;
  * @author Kerstin Breiteneder
  * @author Christoph Wimberger
  * @author Ivan Dubrov
+ * @author Przemysław Rumik
  */
 public class MainWindow extends JFrame {
 
@@ -84,7 +85,7 @@ public class MainWindow extends JFrame {
             title.setOpaque(true);
             title.setBackground(new Color(238, 238, 255));
             return title;
-        } catch (IOException ex) {
+        } catch (Exception ignore) {
         }
         return new JLabel();
     }
@@ -101,6 +102,7 @@ public class MainWindow extends JFrame {
         StringBuilder licenseText = new StringBuilder();
         licenseText.append("Enhance current Java (JRE/JDK) installations with DCEVM (http://github.com/dcevm/dcevm).");
         licenseText.append("\n\nYou can either replace current Java VM or install DCEVM as alternative JVM (run with -XXaltjvm=dcevm command-line option).");
+        licenseText.append("\nInstallation as alternative JVM is preferred, it gives you more control where you will use DCEVM.\nWhy this is important? Because DCEVM forces your JVM to use only one GC algorithm, and this may cause performance penalty.");
         licenseText.append("\n\n\nThis program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 only, as published by the Free Software Foundation.\n\nThis code is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License version 2 for more details (a copy is included in the LICENSE file that accompanied this code).\n\nYou should have received a copy of the GNU General Public License version 2 along with this work; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.");
         licenseText.append("\n\n\nASM LICENSE TEXT:\nCopyright (c) 2000-2005 INRIA, France Telecom\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holders nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.");
         license.setText(licenseText.toString());


### PR DESCRIPTION
Main change here is in Installer.java where scanDirectory was changed to work recursively, thanks to this we are able to find JVM on macOS which are in less predicable places ;-) on macOS JVM location will be for example /Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home, but scaning /Library/Java/JavaVirtualMachines/ without this recursive thing will not find JVM.

Additionally changed text in MainWindow which suggests now that users should prefer alternate JVM over replace JVM, with short "explanation" why.