### PR TITLE
"#168 Extend Installer for SAP JVM"

### DIFF
--- a/installer/src/main/java/com/github/dcevm/installer/ConfigurationInfo.java
+++ b/installer/src/main/java/com/github/dcevm/installer/ConfigurationInfo.java
@@ -38,6 +38,7 @@ import java.util.regex.Pattern;
  * @author Ivan Dubrov
  * @author Jiri Bubnik
  * @author Przemysław Rumik
+ * @author Denis Zygann
  */
 public enum ConfigurationInfo {
 
@@ -262,7 +263,8 @@ public enum ConfigurationInfo {
     }
 
     public boolean is64Bit(Path jreDir) {
-        return getVersionString(jreDir, false).contains("64-Bit");
+        String versionString = getVersionString(jreDir, false);
+        return versionString.contains("64-Bit") || versionString.contains("amd64");
     }
 
     public String getJavaVersion(Path jreDir) throws IOException {


### PR DESCRIPTION
The SAP JVM doesn't return the "64-bit" identifier. I add a check for the identifier "amd64".